### PR TITLE
AccessControlClient custom url order of operations bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log - @itwin/access-control-client
 
+## 1.1.1
+
+- AccessControlClient custom url bug fix
+
 ## 1.1.0
 
 - Added constructor parameter to AccessControlClient for custom url.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/access-control-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Access control client for the iTwin platform",
   "main": "lib/cjs/access-control-client.js",
   "module": "lib/esm/access-control-client.js",

--- a/src/AccessControlClient.ts
+++ b/src/AccessControlClient.ts
@@ -11,13 +11,13 @@ import { PermissionsClient } from "./subClients/PermissionsClient";
 import { RolesClient } from "./subClients/RolesClient";
 
 export class AccessControlClient implements IAccessControlClient {
-  private _baseUrl?: string;
+  public permissions: IPermissionsClient;
+  public roles: IRolesClient;
+  public members: IMembersClient;
 
   public constructor(url?: string){
-    this._baseUrl = url;
+    this.permissions = new PermissionsClient(url)
+    this.roles = new RolesClient(url);
+    this.members = new MembersClient(url)
   }
-
-  public permissions: IPermissionsClient = new PermissionsClient(this._baseUrl);
-  public roles: IRolesClient = new RolesClient(this._baseUrl);
-  public members: IMembersClient = new MembersClient(this._baseUrl);
 }


### PR DESCRIPTION
Order of class initialization is different in javascript and because of that the custom url is set to `undefined` ([section about it in TS documentation](https://www.typescriptlang.org/docs/handbook/2/classes.html#initialization-order)).
This can be also seen in the delivered package code:
![image](https://user-images.githubusercontent.com/55551604/196695050-69ee466e-28cf-4f84-908b-820bb60dd82e.png)
 