### PR TITLE
Add APIM Versioning support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/access-control-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Access control client for the iTwin platform",
   "main": "lib/cjs/access-control-client.js",
   "module": "lib/esm/access-control-client.js",

--- a/src/subClients/BaseClient.ts
+++ b/src/subClients/BaseClient.ts
@@ -74,7 +74,7 @@ export class BaseClient {
       headers: {
         "authorization": accessTokenString,
         "content-type": "application/json",
-        "accept": "application/vnd.bentley.itwin-platform.v2+json",
+        "accept": "application/vnd.bentley.itwin-platform.v1+json",
       },
       validateStatus(status) {
         return status < 500; // Resolve only if the status code is less than 500

--- a/src/subClients/BaseClient.ts
+++ b/src/subClients/BaseClient.ts
@@ -74,6 +74,7 @@ export class BaseClient {
       headers: {
         "authorization": accessTokenString,
         "content-type": "application/json",
+        "accept": "application/vnd.bentley.itwin-platform.v2+json",
       },
       validateStatus(status) {
         return status < 500; // Resolve only if the status code is less than 500


### PR DESCRIPTION
The Access Control API has now been versioned. Currently the we are not passing in the `accept` header which points to the correct version of the API. This value is not required by APIM, and will get set to the default version of the API, which right now is V1. When V2 gets to general access that will be set to the default and will break parts of this client. This PR is in anticipation of that happening.