### PR TITLE
Return User Object From Group

### DIFF
--- a/src/accessControlTypes.ts
+++ b/src/accessControlTypes.ts
@@ -233,7 +233,7 @@ export interface Group {
   id?: string;
   name?: string;
   description?: string;
-  users?: GroupUser[];
+  members?: GroupUser[];
   imsGroups?: string[];
 }
 

--- a/src/accessControlTypes.ts
+++ b/src/accessControlTypes.ts
@@ -233,6 +233,14 @@ export interface Group {
   id?: string;
   name?: string;
   description?: string;
-  users?: string[];
+  users?: GroupUser[];
   imsGroups?: string[];
+}
+
+export interface GroupUser {
+  id?: string;
+  email?: string;
+  givenName?: string;
+  surname?: string;
+  organization?: string;
 }

--- a/src/test/integration/accessControlClientGroups.test.ts
+++ b/src/test/integration/accessControlClientGroups.test.ts
@@ -149,7 +149,7 @@ describe("AccessControlClient Groups", () => {
     chai.expect(updateResponse.data!.name).to.be.eq(updatedGroup.name);
     chai.expect(updateResponse.data!.description).to.be.eq(updatedGroup.description);
     chai
-      .expect(updateResponse.data!.users!.map((x) => x))
+      .expect(updateResponse.data!.members!.map((x) => x))
       .to.include(TestConfig.temporaryUserEmail);
     chai
       .expect(updateResponse.data!.imsGroups!.map((x) => x))
@@ -158,7 +158,7 @@ describe("AccessControlClient Groups", () => {
     // --- UPDATE GROUP BACK TO EMPTY---
     // Arrange
     const updatedEmptyGroup: Group = {
-      users: [],
+      members: [],
       imsGroups: [],
     };
 
@@ -170,7 +170,7 @@ describe("AccessControlClient Groups", () => {
     chai.expect(updateEmptyResponse.status).to.be.eq(200);
     chai.expect(updateEmptyResponse.data!.name).to.be.eq(updatedGroup.name);
     chai.expect(updateEmptyResponse.data!.description).to.be.eq(updatedGroup.description);
-    chai.expect(updateEmptyResponse.data!.users!.length).to.be.eq(0);
+    chai.expect(updateEmptyResponse.data!.members!.length).to.be.eq(0);
     chai.expect(updateEmptyResponse.data!.imsGroups!.length).to.be.eq(0);
 
     // --- DELETE GROUP ---

--- a/src/test/integration/accessControlClientGroups.test.ts
+++ b/src/test/integration/accessControlClientGroups.test.ts
@@ -127,7 +127,13 @@ describe("AccessControlClient Groups", () => {
 
     // --- UPDATE GROUP ---
     // Arrange
-    const updatedGroup: Group = {
+    const updatedGroup: {
+      id?: string;
+      name?: string;
+      description?: string;
+      users?: string[];
+      imsGroups?: string[];
+    } = {
       name: `${newGroupName} Updated Name`,
       description: `${newGroupDescription} Updated Description`,
       users: [TestConfig.temporaryUserEmail],


### PR DESCRIPTION
Instead of just returning the email, the members object will now return the entire user object.