### PR TITLE
3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log - @itwin/access-control-client
 
-## 3.0.2
+## 3.1.0
 
+- Adding iTwin jobs client
 - Upgrading axios version to ^1.7.4
 
 ## 3.0.0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ import {
 
 /** Function that queries all Roles for a given iTwin and prints their ids to the console. */
 async function printiTwinRoleIds(): Promise<void> {
-  const accessControlClient: IAccessControlClient = new AccessControlClient("https://api.bentley.com/accesscontrol/itwins");
+  const accessControlClient: IAccessControlClient = new AccessControlClient(
+    "https://api.bentley.com/accesscontrol/itwins"
+  );
   const accessToken: AccessToken = { get_access_token_logic_here };
 
   const iTwinsResponse: AccessControlAPIResponse<Role[]> =
@@ -276,6 +278,7 @@ async function printiTwinRole(): Promise<void> {
     );
 }
 ```
+
 ### Get list of Owner Members for an iTwin
 
 ```typescript
@@ -381,7 +384,9 @@ import {
 
 /** Function that queries all Groups for a given iTwin and prints their ids to the console. */
 async function printiTwinGroupIds(): Promise<void> {
-  const accessControlClient: IAccessControlClient = new AccessControlClient("https://api.bentley.com/accesscontrol/itwins");
+  const accessControlClient: IAccessControlClient = new AccessControlClient(
+    "https://api.bentley.com/accesscontrol/itwins"
+  );
   const accessToken: AccessToken = { get_access_token_logic_here };
 
   const iTwinsResponse: AccessControlAPIResponse<Group[]> =
@@ -453,7 +458,7 @@ async function printiTwinGroup(): Promise<void> {
     name: "Some new group name",
     description: "UPDATED GROUP DESCRIPTION",
     user: ["John.Johnson@example.com"],
-    imsGroups: ["Sample IMS Group"]
+    imsGroups: ["Sample IMS Group"],
   };
   const updateResponse: AccessControlAPIResponse<Group> =
     await accessControlClient.groups.updateITwinGroupAsync(
@@ -656,6 +661,78 @@ async function printiTwinPermissionIds(): Promise<void> {
   iTwinsResponse.data!.forEach((actualPermission: Permission) => {
     console.log(actualPermission.id);
   });
+}
+```
+
+### Create and get iTwin job and related actions
+
+```typescript
+import type { AccessToken } from "@itwin/core-bentley";
+import {
+  AccessControlClient,
+  IAccessControlClient,
+  ITwinJob,
+  ITwinJobActions,
+  AccessControlAPIResponse,
+} from "@itwin/access-control-client";
+
+/** Function that creates, updates, and deletes a user member. */
+async function printiTwinRole(): Promise<void> {
+  const accessControlClient: IAccessControlClient = new AccessControlClient();
+  const accessToken: AccessToken = { get_access_token_logic_here };
+
+  const itwinJobActions = {
+    assignRoles: [
+      {
+        email: "John.Johnson@example.com",
+        roleIds: ["65819672-962d-4386-8667-136125bcb7b2"],
+      },
+    ],
+    unassignRoles: [
+      {
+        email: "Maria.Miller@example.com",
+        roleIds: ["d6a62e34-5016-4bac-a9a0-a6522583698e"],
+      },
+    ],
+    removeMembers: [
+      {
+        email: "Jobby.McJobface@example.com",
+      },
+    ],
+  };
+
+  // Create iTwin job
+  const createResponse: AccessControlAPIResponse<ITwinJob> =
+    await accessControlClient.itwinJobs.createITwinJobAsync(
+      accessToken,
+      "d7d82799-3f0c-4175-acbe-cc2573e99359",
+      itwinJobActions
+    );
+
+  // Get the created iTwin job
+  const getiTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+    await accessControlClient.itwinJobs.getITwinJobAsync(
+      accessToken,
+      "d7d82799-3f0c-4175-acbe-cc2573e99359",
+      createResponse.data.id
+    );
+
+  // Get the created iTwin job with errors
+  const getiTwinJobResponseWithErrors: AccessControlAPIResponse<ITwinJob> =
+    await accessControlClient.itwinJobs.getITwinJobAsync(
+      accessToken,
+      "d7d82799-3f0c-4175-acbe-cc2573e99359",
+      createResponse.data.id,
+      "representation"
+    );
+
+  // Get the created iTwin job's actions
+  const getiTwinJobActionaResponse: AccessControlAPIResponse<ITwinJobActions> =
+    await accessControlClient.itwinJobs.getITwinJobActionsAsync(
+      accessToken,
+      "d7d82799-3f0c-4175-acbe-cc2573e99359",
+      createResponse.data.id
+    );
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/access-control-client",
-  "version": "3.0.2",
+  "version": "3.1.0-beta.1",
   "description": "Access control client for the iTwin platform",
   "main": "lib/cjs/access-control-client.js",
   "module": "lib/esm/access-control-client.js",

--- a/src/AccessControlClient.ts
+++ b/src/AccessControlClient.ts
@@ -9,6 +9,7 @@ import type {
   IAccessControlClient,
   IGroupMembersClient,
   IGroupsClient,
+  IITwinJobsClient,
   IMemberInvitationsClient,
   IOwnerMembersClient,
   IPermissionsClient,
@@ -22,6 +23,7 @@ import { UserMembersClient } from "./subClients/UserMembersClient";
 import { GroupMembersClient } from "./subClients/GroupMembersClient";
 import { OwnerMembersClient } from "./subClients/OwnerMembersClient";
 import { MemberInvitationsClient } from "./subClients/MemberInvitationsClient";
+import { ITwinJobsClient } from "./subClients/ITwinJobsClient";
 
 export class AccessControlClient implements IAccessControlClient {
   public permissions: IPermissionsClient;
@@ -31,6 +33,7 @@ export class AccessControlClient implements IAccessControlClient {
   public groupMembers: IGroupMembersClient;
   public ownerMembers: IOwnerMembersClient;
   public memberInvitations: IMemberInvitationsClient;
+  public itwinJobs: IITwinJobsClient;
 
   public constructor(url?: string) {
     this.permissions = new PermissionsClient(url);
@@ -40,5 +43,6 @@ export class AccessControlClient implements IAccessControlClient {
     this.groupMembers = new GroupMembersClient(url);
     this.ownerMembers = new OwnerMembersClient(url);
     this.memberInvitations = new MemberInvitationsClient(url);
+    this.itwinJobs = new ITwinJobsClient(url);
   }
 }

--- a/src/accessControlTypes.ts
+++ b/src/accessControlTypes.ts
@@ -19,6 +19,7 @@ export interface IAccessControlClient {
   groupMembers: IGroupMembersClient;
   ownerMembers: IOwnerMembersClient;
   memberInvitations: IMemberInvitationsClient;
+  itwinJobs: IITwinJobsClient;
 }
 
 export interface IPermissionsClient {
@@ -217,13 +218,43 @@ export interface IMemberInvitationsClient {
   ): Promise<AccessControlAPIResponse<MemberInvitation[]>>;
 }
 
+export interface IITwinJobsClient {
+  /** Creates a new iTwin Job */
+  createITwinJobAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobActions: ITwinJobActions
+  ): Promise<AccessControlAPIResponse<ITwinJob>>;
+
+  /** Gets an iTwin Job. To see errors, pass in the `representation` result mode. */
+  getITwinJobAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobId?: string,
+    resultMode?: AccessControlResultMode
+  ): Promise<AccessControlAPIResponse<ITwinJob>>;
+
+  /** Gets the iTwin Job Actions for a specified iTwin Job. */
+  getITwinJobActionsAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobId?: string
+  ): Promise<AccessControlAPIResponse<ITwinJobActions>>;
+}
+
 //#endregion
 
 //#region generic-responses
 
+/**
+ * Optional result mode. Minimal is the default, representation returns extra properties
+ */
+export type AccessControlResultMode = "minimal" | "representation";
+
 export interface AccessControlQueryArg {
   top?: number;
   skip?: number;
+  resultMode?: AccessControlResultMode;
 }
 
 export interface AccessControlAPIResponse<T> {
@@ -343,6 +374,36 @@ export interface MemberInvitation {
 export enum MemberInvitationStatus {
   Pending = "Pending",
   Accepted = "Accepted"
+}
+
+export enum ITwinJobStatus {
+  Active = "Active",
+  Complete = "Completed",
+  PartialCompleted = "PartialCompleted",
+  Failed = "Failed"
+}
+
+/** Contains extra properties with "representation" result mode.
+ */
+export interface ITwinJob {
+  id: string;
+  itwinId: string;
+  status: ITwinJobStatus;
+
+  // extra properties available with "representation" result mode:
+  error?: ErrorDetail[];
+}
+
+export interface ITwinJobActions {
+  assignRoles?: ITwinJobAction[];
+  unassignRoles?: ITwinJobAction[];
+  removeMembers?: Omit<ITwinJobAction, "roleIds">[];
+  options?: any;
+}
+
+export interface ITwinJobAction {
+  email: string;
+  roleIds: string[];
 }
 
 //#endregion

--- a/src/subClients/ITwinJobsClient.ts
+++ b/src/subClients/ITwinJobsClient.ts
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module AccessControlClient
+ */
+import type { AccessToken } from "@itwin/core-bentley";
+import type { AccessControlAPIResponse, AccessControlResultMode, IITwinJobsClient, ITwinJob, ITwinJobActions } from "../accessControlTypes";
+import { BaseClient } from "./BaseClient";
+
+export class ITwinJobsClient extends BaseClient implements IITwinJobsClient {
+  public constructor(url?: string) {
+    super(url);
+  }
+
+  /** Create a new iTwin Job
+     * @param accessToken The client access token string
+     * @param iTwinId The id of the iTwin
+     * @param iTwinActions The actions of the iTwin Job
+     * @returns ITwin Job
+     */
+  public async createITwinJobAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobActions: ITwinJobActions
+  ): Promise<AccessControlAPIResponse<ITwinJob>> {
+    const url = `${this._baseUrl}/${iTwinId}/jobs`;
+    return this.sendGenericAPIRequest(accessToken, "POST", url, { actions: iTwinJobActions });
+  }
+
+  /** Gets an iTwin Job.
+     * @param accessToken The client access token string
+     * @param iTwinId The id of the iTwin
+     * @param iTwinJobId The id of the iTwin Job
+     * @param resultMode (Optional) Access Control result mode: minimal or representation (defaults to minimal)
+     * @returns ITwin Job
+     */
+  public async getITwinJobAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobId: string,
+    resultMode?: AccessControlResultMode
+  ): Promise<AccessControlAPIResponse<ITwinJob>> {
+    const headers = this.getResultModeHeaders(resultMode);
+    const url = `${this._baseUrl}/${iTwinId}/jobs/${iTwinJobId}`;
+    return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, undefined, headers);
+  }
+
+  /** Gets an iTwin Job.
+     * @param accessToken The client access token string
+     * @param iTwinId The id of the iTwin
+     * @param iTwinJobId The id of the iTwin Job
+     * @returns ITwin Job Actions
+     */
+  public async getITwinJobActionsAsync(
+    accessToken: AccessToken,
+    iTwinId: string,
+    iTwinJobId?: string
+  ): Promise<AccessControlAPIResponse<ITwinJobActions>> {
+    const url = `${this._baseUrl}/${iTwinId}/jobs/${iTwinJobId}/actions`;
+    return this.sendGenericAPIRequest(accessToken, "GET", url, undefined, "actions");
+  }
+
+  /**
+   * Format result mode parameter into a headers entry
+   * @param resultMode (Optional) Access Control result mode
+   * @protected
+   */
+  protected getResultModeHeaders(resultMode: AccessControlResultMode = "minimal"): Record<string, string> {
+    return {
+      prefer: `return=${resultMode}`,
+    };
+  }
+}

--- a/src/test/TestConfig.ts
+++ b/src/test/TestConfig.ts
@@ -31,7 +31,7 @@ export class TestConfig {
 
   public static readonly regularUserId: string = process.env.IMJS_TEST_REGULAR_USER_ID!;
 
-  public static readonly projectId: string = process.env.IMJS_TEST_ITWIN_ID!;
+  public static readonly itwinId: string = process.env.IMJS_TEST_ITWIN_ID!;
 
   /** Login the specified user and return the AuthorizationToken */
   public static async getAccessToken(

--- a/src/test/integration/accessControlClientGroupMembers.test.ts
+++ b/src/test/integration/accessControlClientGroupMembers.test.ts
@@ -36,7 +36,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember[]> =
       await accessControlClient.groupMembers.queryITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -50,7 +50,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember[]> =
       await customAccessControlClient.groupMembers.queryITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -67,7 +67,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember[]> =
       await accessControlClient.groupMembers.queryITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { top: topAmount }
       );
 
@@ -83,7 +83,7 @@ describe("AccessControlClient Group Members", () => {
     const unFilteredList: AccessControlAPIResponse<GroupMember[]> =
       await accessControlClient.groupMembers.queryITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
     const skipAmmount = 1;
     const topAmount = 3;
@@ -92,7 +92,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember[]> =
       await accessControlClient.groupMembers.queryITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { skip: skipAmmount, top: topAmount }
       );
 
@@ -111,7 +111,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember> =
       await accessControlClient.groupMembers.getITwinGroupMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         TestConfig.permanentGroupId1
       );
 
@@ -129,7 +129,7 @@ describe("AccessControlClient Group Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<GroupMember> =
       await accessControlClient.groupMembers.getITwinGroupMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         notExistantGroupId
       );
 
@@ -145,7 +145,7 @@ describe("AccessControlClient Group Members", () => {
     const addUserMemberResponse: AccessControlAPIResponse<GroupMember[]> =
       await accessControlClient.groupMembers.addITwinGroupMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         [
           {
             groupId: TestConfig.permanentGroupId2,
@@ -164,7 +164,7 @@ describe("AccessControlClient Group Members", () => {
     const getGroupMemberResponse: AccessControlAPIResponse<GroupMember> =
       await accessControlClient.groupMembers.getITwinGroupMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         TestConfig.permanentGroupId2
       );
 
@@ -183,7 +183,7 @@ describe("AccessControlClient Group Members", () => {
     const updatedUserMemberResponse: AccessControlAPIResponse<GroupMember> =
       await accessControlClient.groupMembers.updateITwinGroupMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         TestConfig.permanentGroupId2,
         [TestConfig.permanentRoleId1, TestConfig.permanentRoleId2]
       );
@@ -206,7 +206,7 @@ describe("AccessControlClient Group Members", () => {
     const removeUserMemberResponse: AccessControlAPIResponse<undefined> =
       await accessControlClient.groupMembers.removeITwinGroupMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         TestConfig.permanentGroupId2
       );
 

--- a/src/test/integration/accessControlClientGroups.test.ts
+++ b/src/test/integration/accessControlClientGroups.test.ts
@@ -29,7 +29,7 @@ describe("AccessControlClient Groups", () => {
   it("should get a list of groups for an iTwin", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Group[]> =
-      await accessControlClient.groups.getITwinGroupsAsync(accessToken, TestConfig.projectId);
+      await accessControlClient.groups.getITwinGroupsAsync(accessToken, TestConfig.itwinId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -40,7 +40,7 @@ describe("AccessControlClient Groups", () => {
   it("should get a list of groups for an iTwin with custom url", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Group[]> =
-      await customAccessControlClient.groups.getITwinGroupsAsync(accessToken, TestConfig.projectId);
+      await customAccessControlClient.groups.getITwinGroupsAsync(accessToken, TestConfig.itwinId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -51,7 +51,7 @@ describe("AccessControlClient Groups", () => {
   it("should get a specific groups for an iTwin", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.getITwinGroupAsync(accessToken, TestConfig.projectId, TestConfig.permanentGroupId1);
+      await accessControlClient.groups.getITwinGroupAsync(accessToken, TestConfig.itwinId, TestConfig.permanentGroupId1);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -66,7 +66,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.getITwinGroupAsync(accessToken, TestConfig.projectId, nonExistantGroupId);
+      await accessControlClient.groups.getITwinGroupAsync(accessToken, TestConfig.itwinId, nonExistantGroupId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -84,7 +84,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.projectId, nonExistantGroupId, emptyUpdatedGroup);
+      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.itwinId, nonExistantGroupId, emptyUpdatedGroup);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -98,7 +98,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<undefined> =
-      await accessControlClient.groups.deleteITwinGroupAsync(accessToken, TestConfig.projectId, nonExistantGroupId);
+      await accessControlClient.groups.deleteITwinGroupAsync(accessToken, TestConfig.itwinId, nonExistantGroupId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -118,7 +118,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const createResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.createITwinGroupAsync(accessToken, TestConfig.projectId, newGroup);
+      await accessControlClient.groups.createITwinGroupAsync(accessToken, TestConfig.itwinId, newGroup);
 
     // Assert
     chai.expect(createResponse.status).to.be.eq(201);
@@ -136,7 +136,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const updateResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.projectId, createResponse.data!.id as string, updatedGroup);
+      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.itwinId, createResponse.data!.id as string, updatedGroup);
 
     // Assert
     chai.expect(updateResponse.status).to.be.eq(200);
@@ -158,7 +158,7 @@ describe("AccessControlClient Groups", () => {
 
     // Act
     const updateEmptyResponse: AccessControlAPIResponse<Group> =
-      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.projectId, createResponse.data!.id as string, updatedEmptyGroup);
+      await accessControlClient.groups.updateITwinGroupAsync(accessToken, TestConfig.itwinId, createResponse.data!.id as string, updatedEmptyGroup);
 
     // Assert
     chai.expect(updateEmptyResponse.status).to.be.eq(200);
@@ -170,7 +170,7 @@ describe("AccessControlClient Groups", () => {
     // --- DELETE GROUP ---
     // Act
     const deleteResponse: AccessControlAPIResponse<undefined> =
-      await accessControlClient.groups.deleteITwinGroupAsync(accessToken, TestConfig.projectId, createResponse.data!.id as string);
+      await accessControlClient.groups.deleteITwinGroupAsync(accessToken, TestConfig.itwinId, createResponse.data!.id as string);
 
     // Assert
     chai.expect(deleteResponse.status).to.be.eq(204);

--- a/src/test/integration/accessControlClientMemberInvitations.test.ts
+++ b/src/test/integration/accessControlClientMemberInvitations.test.ts
@@ -37,7 +37,7 @@ describe("AccessControlClient Member Invitations", () => {
     const getMemberInvitationsResponse: AccessControlAPIResponse<MemberInvitation[]> =
       await accessControlClient.memberInvitations.queryITwinMemberInvitationsAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
     chai.expect(getMemberInvitationsResponse.status).to.be.eq(200);
     chai.expect(getMemberInvitationsResponse.data).to.not.be.null;
@@ -46,7 +46,7 @@ describe("AccessControlClient Member Invitations", () => {
       const addUserMemberResponse: AccessControlAPIResponse<AddUserMemberResponse> =
       await accessControlClient.userMembers.addITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         [
           {
             email: `access-control-client-${randomIntFromInterval(0, 10000)}@example.com`,
@@ -95,7 +95,7 @@ describe("AccessControlClient Member Invitations", () => {
     const iTwinsResponse: AccessControlAPIResponse<MemberInvitation[]> =
       await accessControlClient.memberInvitations.queryITwinMemberInvitationsAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -112,7 +112,7 @@ describe("AccessControlClient Member Invitations", () => {
     const iTwinsResponse: AccessControlAPIResponse<MemberInvitation[]> =
     await accessControlClient.memberInvitations.queryITwinMemberInvitationsAsync(
       accessToken,
-      TestConfig.projectId,
+      TestConfig.itwinId,
       { top: topAmount }
     );
 
@@ -128,7 +128,7 @@ describe("AccessControlClient Member Invitations", () => {
     const unFilteredList: AccessControlAPIResponse<MemberInvitation[]> =
     await accessControlClient.memberInvitations.queryITwinMemberInvitationsAsync(
       accessToken,
-      TestConfig.projectId
+      TestConfig.itwinId
     );
     const skipAmmount = 5;
     const topAmount = 3;
@@ -137,7 +137,7 @@ describe("AccessControlClient Member Invitations", () => {
     const iTwinsResponse: AccessControlAPIResponse<MemberInvitation[]> =
     await accessControlClient.memberInvitations.queryITwinMemberInvitationsAsync(
       accessToken,
-      TestConfig.projectId,
+      TestConfig.itwinId,
       { skip: skipAmmount, top: topAmount }
     );
 

--- a/src/test/integration/accessControlClientOwnerMembers.test.ts
+++ b/src/test/integration/accessControlClientOwnerMembers.test.ts
@@ -38,7 +38,7 @@ describe("AccessControlClient Owner Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<OwnerMember[]> =
       await accessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -52,7 +52,7 @@ describe("AccessControlClient Owner Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<OwnerMember[]> =
       await customAccessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
       );
 
     // Assert
@@ -69,7 +69,7 @@ describe("AccessControlClient Owner Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<OwnerMember[]> =
       await accessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { top: topAmount }
       );
 
@@ -85,7 +85,7 @@ describe("AccessControlClient Owner Members", () => {
     const unFilteredList: AccessControlAPIResponse<OwnerMember[]> =
       await accessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
     const skipAmmount = 1;
     const topAmount = 1;
@@ -94,7 +94,7 @@ describe("AccessControlClient Owner Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<OwnerMember[]> =
       await accessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { skip: skipAmmount, top: topAmount }
       );
 
@@ -114,7 +114,7 @@ describe("AccessControlClient Owner Members", () => {
     const addOwnerMemberResponse: AccessControlAPIResponse<AddOwnerMemberResponse> =
       await accessControlClient.ownerMembers.addITwinOwnerMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         {
           email: TestUsers.manager.email,
         },
@@ -130,7 +130,7 @@ describe("AccessControlClient Owner Members", () => {
     const queryOwnerMemberResponse: AccessControlAPIResponse<OwnerMember[]> =
       await accessControlClient.ownerMembers.queryITwinOwnerMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     chai.expect(queryOwnerMemberResponse.status).to.be.eq(200);
@@ -146,7 +146,7 @@ describe("AccessControlClient Owner Members", () => {
     const removeOwnerMemberResponse: AccessControlAPIResponse<undefined> =
       await accessControlClient.ownerMembers.removeITwinOwnerMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         newOwner.id!
       );
 

--- a/src/test/integration/accessControlClientPermissions.test.ts
+++ b/src/test/integration/accessControlClientPermissions.test.ts
@@ -51,7 +51,7 @@ describe("AccessControlClient Permissions", () => {
   it("should get a list of permissions for an iTwin", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Permission[]> =
-      await accessControlClient.permissions.getITwinPermissionsAsync(accessToken, TestConfig.projectId);
+      await accessControlClient.permissions.getITwinPermissionsAsync(accessToken, TestConfig.itwinId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);

--- a/src/test/integration/accessControlClientRoles.test.ts
+++ b/src/test/integration/accessControlClientRoles.test.ts
@@ -29,7 +29,7 @@ describe("AccessControlClient Roles", () => {
   it("should get a list of roles for an iTwin", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role[]> =
-      await accessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.projectId);
+      await accessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.itwinId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -40,7 +40,7 @@ describe("AccessControlClient Roles", () => {
   it("should get a list of roles for an iTwin with custom url", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role[]> =
-      await customAccessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.projectId);
+      await customAccessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.itwinId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -51,7 +51,7 @@ describe("AccessControlClient Roles", () => {
   it("should get a list of roles for an iTwin with additional headers", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role[]> =
-      await customAccessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.projectId, { "test-custom-header": "custom-value:xyz-123-abc" });
+      await customAccessControlClient.roles.getITwinRolesAsync(accessToken, TestConfig.itwinId, { "test-custom-header": "custom-value:xyz-123-abc" });
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -62,7 +62,7 @@ describe("AccessControlClient Roles", () => {
   it("should get a specific role for an iTwin", async () => {
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role> =
-      await accessControlClient.roles.getITwinRoleAsync(accessToken, TestConfig.projectId, TestConfig.permanentRoleId1);
+      await accessControlClient.roles.getITwinRoleAsync(accessToken, TestConfig.itwinId, TestConfig.permanentRoleId1);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(200);
@@ -77,7 +77,7 @@ describe("AccessControlClient Roles", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role> =
-      await accessControlClient.roles.getITwinRoleAsync(accessToken, TestConfig.projectId, nonExistantRoleId);
+      await accessControlClient.roles.getITwinRoleAsync(accessToken, TestConfig.itwinId, nonExistantRoleId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -96,7 +96,7 @@ describe("AccessControlClient Roles", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<Role> =
-      await accessControlClient.roles.updateITwinRoleAsync(accessToken, TestConfig.projectId, nonExistantRoleId, emptyUpdatedRole);
+      await accessControlClient.roles.updateITwinRoleAsync(accessToken, TestConfig.itwinId, nonExistantRoleId, emptyUpdatedRole);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -110,7 +110,7 @@ describe("AccessControlClient Roles", () => {
 
     // Act
     const iTwinsResponse: AccessControlAPIResponse<undefined> =
-      await accessControlClient.roles.deleteITwinRoleAsync(accessToken, TestConfig.projectId, nonExistantRoleId);
+      await accessControlClient.roles.deleteITwinRoleAsync(accessToken, TestConfig.itwinId, nonExistantRoleId);
 
     // Assert
     chai.expect(iTwinsResponse.status).to.be.eq(404);
@@ -131,7 +131,7 @@ describe("AccessControlClient Roles", () => {
 
     // Act
     const createResponse: AccessControlAPIResponse<Role> =
-      await accessControlClient.roles.createITwinRoleAsync(accessToken, TestConfig.projectId, newRole);
+      await accessControlClient.roles.createITwinRoleAsync(accessToken, TestConfig.itwinId, newRole);
 
     // Assert
     chai.expect(createResponse.status).to.be.eq(201);
@@ -148,7 +148,7 @@ describe("AccessControlClient Roles", () => {
 
     // Act
     const updateResponse: AccessControlAPIResponse<Role> =
-      await accessControlClient.roles.updateITwinRoleAsync(accessToken, TestConfig.projectId, createResponse.data!.id!, updatedRole);
+      await accessControlClient.roles.updateITwinRoleAsync(accessToken, TestConfig.itwinId, createResponse.data!.id!, updatedRole);
 
     // Assert
     chai.expect(updateResponse.status).to.be.eq(200);
@@ -158,7 +158,7 @@ describe("AccessControlClient Roles", () => {
     // --- DELETE ROLE ---
     // Act
     const deleteResponse: AccessControlAPIResponse<undefined> =
-      await accessControlClient.roles.deleteITwinRoleAsync(accessToken, TestConfig.projectId, createResponse.data!.id!);
+      await accessControlClient.roles.deleteITwinRoleAsync(accessToken, TestConfig.itwinId, createResponse.data!.id!);
 
     // Assert
     chai.expect(deleteResponse.status).to.be.eq(204);

--- a/src/test/integration/accessControlClientUserMembers.test.ts
+++ b/src/test/integration/accessControlClientUserMembers.test.ts
@@ -38,7 +38,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember[]> =
       await accessControlClient.userMembers.queryITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -52,7 +52,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember[]> =
       await customAccessControlClient.userMembers.queryITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
 
     // Assert
@@ -69,7 +69,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember[]> =
       await accessControlClient.userMembers.queryITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { top: topAmount }
       );
 
@@ -85,7 +85,7 @@ describe("AccessControlClient User Members", () => {
     const unFilteredList: AccessControlAPIResponse<UserMember[]> =
       await accessControlClient.userMembers.queryITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId
+        TestConfig.itwinId
       );
     const skipAmmount = 5;
     const topAmount = 3;
@@ -94,7 +94,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember[]> =
       await accessControlClient.userMembers.queryITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         { skip: skipAmmount, top: topAmount }
       );
 
@@ -113,7 +113,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember> =
       await accessControlClient.userMembers.getITwinUserMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         TestConfig.regularUserId
       );
 
@@ -131,7 +131,7 @@ describe("AccessControlClient User Members", () => {
     const iTwinsResponse: AccessControlAPIResponse<UserMember> =
       await accessControlClient.userMembers.getITwinUserMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         notExistantUserId
       );
 
@@ -147,7 +147,7 @@ describe("AccessControlClient User Members", () => {
     const addUserMemberResponse: AccessControlAPIResponse<AddUserMemberResponse> =
       await accessControlClient.userMembers.addITwinUserMembersAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         [
           {
             email: TestUsers.regular.email,
@@ -168,7 +168,7 @@ describe("AccessControlClient User Members", () => {
     const getUserMemberResponse: AccessControlAPIResponse<UserMember> =
       await accessControlClient.userMembers.getITwinUserMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         newMember.id!
       );
 
@@ -187,7 +187,7 @@ describe("AccessControlClient User Members", () => {
     const updatedUserMemberResponse: AccessControlAPIResponse<UserMember> =
       await accessControlClient.userMembers.updateITwinUserMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         newMember.id!,
         [TestConfig.permanentRoleId1, TestConfig.permanentRoleId2]
       );
@@ -210,7 +210,7 @@ describe("AccessControlClient User Members", () => {
     const removeUserMemberResponse: AccessControlAPIResponse<undefined> =
       await accessControlClient.userMembers.removeITwinUserMemberAsync(
         accessToken,
-        TestConfig.projectId,
+        TestConfig.itwinId,
         newMember.id!
       );
 

--- a/src/test/integration/accessControlClientiTwinJob.test.ts
+++ b/src/test/integration/accessControlClientiTwinJob.test.ts
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { AccessToken } from "@itwin/core-bentley";
+import * as chai from "chai";
+import { AccessControlClient } from "../../AccessControlClient";
+import type { AccessControlAPIResponse, IAccessControlClient, ITwinJob, ITwinJobActions } from "../../accessControlTypes";
+import { TestConfig } from "../TestConfig";
+
+chai.should();
+describe("AccessControlClient iTwin Jobs", () => {
+  const accessControlClient: IAccessControlClient = new AccessControlClient();
+  let accessToken: AccessToken;
+
+  let testJob: ITwinJob;
+  let testiTwinJobActions: ITwinJobActions;
+
+  before(async function () {
+    accessToken = await TestConfig.getAccessToken();
+    testiTwinJobActions = { assignRoles : [{ email: TestConfig.temporaryUserEmail, roleIds: [TestConfig.permanentRoleId1]} ]};
+
+    const testJobResponse = await accessControlClient.itwinJobs.createITwinJobAsync(accessToken, TestConfig.itwinId, testiTwinJobActions);
+    testJob = testJobResponse.data!;
+  });
+
+  it("should get a specific iTwin Job", async () => {
+    // Act
+    const iTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+      await accessControlClient.itwinJobs.getITwinJobAsync(accessToken, TestConfig.itwinId, testJob.id);
+
+    // Assert
+    chai.expect(iTwinJobResponse.status).to.be.eq(200);
+    chai.expect(iTwinJobResponse.data).to.not.be.empty;
+
+    chai.expect(iTwinJobResponse.data!.id).to.be.eq(testJob.id);
+    chai.expect(iTwinJobResponse.data!.itwinId).to.be.eq(TestConfig.itwinId);
+  });
+
+  it("should get a specific iTwin Job with minimal result mode", async () => {
+    // Act
+    const iTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+      await accessControlClient.itwinJobs.getITwinJobAsync(accessToken, TestConfig.itwinId, testJob.id, "minimal");
+
+    // Assert
+    chai.expect(iTwinJobResponse.status).to.be.eq(200);
+    chai.expect(iTwinJobResponse.data).to.not.be.empty;
+
+    chai.expect(iTwinJobResponse.data!.id).to.be.eq(testJob.id);
+    chai.expect(iTwinJobResponse.data!.itwinId).to.be.eq(TestConfig.itwinId);
+
+    chai.expect(iTwinJobResponse.data!.error).to.be.undefined;
+  });
+
+  it("should get a specific iTwin Job with representation return", async () => {
+    // Act
+    const iTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+      await accessControlClient.itwinJobs.getITwinJobAsync(accessToken, TestConfig.itwinId, testJob.id, "representation");
+
+    // Assert
+    chai.expect(iTwinJobResponse.status).to.be.eq(200);
+    chai.expect(iTwinJobResponse.data).to.not.be.empty;
+
+    chai.expect(iTwinJobResponse.data!.id).to.be.eq(testJob.id);
+    chai.expect(iTwinJobResponse.data!.itwinId).to.be.eq(TestConfig.itwinId);
+
+    chai.expect(iTwinJobResponse.data!.error).should.not.equal(undefined);
+  });
+
+  it("should get a 404 when trying to get a non-existant iTwin Job", async () => {
+    // Act
+    const iTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+      await accessControlClient.itwinJobs.getITwinJobAsync(accessToken, TestConfig.itwinId, "non-existant-job-id");
+
+    // Assert
+    chai.expect(iTwinJobResponse.status).to.be.eq(404);
+  });
+
+  it("should get a specific iTwin Job Actions", async () => {
+    // Act
+    const iTwinJobActionsResponse: AccessControlAPIResponse<ITwinJobActions> =
+      await accessControlClient.itwinJobs.getITwinJobActionsAsync(accessToken, TestConfig.itwinId, testJob.id);
+
+    // Assert
+    chai.expect(iTwinJobActionsResponse.status).to.be.eq(200);
+    chai.expect(iTwinJobActionsResponse.data).to.not.be.empty;
+
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles).to.be.not.empty;
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles!.length).to.be.eq(1);
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles![0].email).to.be.eq(TestConfig.temporaryUserEmail);
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles![0].roleIds).to.be.not.empty;
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles![0].roleIds.length).to.be.eq(1);
+    chai.expect(iTwinJobActionsResponse.data!.assignRoles![0].roleIds[0]).to.be.eq(TestConfig.permanentRoleId1);
+  });
+
+  it("should get a 404 when trying to get a non-existant iTwin Job Actions", async () => {
+    // Act
+    const iTwinJobActionsResponse: AccessControlAPIResponse<ITwinJobActions> =
+      await accessControlClient.itwinJobs.getITwinJobActionsAsync(accessToken, TestConfig.itwinId, "non-existant-job-id");
+
+    // Assert
+    chai.expect(iTwinJobActionsResponse.status).to.be.eq(404);
+  });
+
+  it("should create a iTwin Job", async () => {
+    // Act
+    const iTwinJobResponse: AccessControlAPIResponse<ITwinJob> =
+      await accessControlClient.itwinJobs.createITwinJobAsync(accessToken, TestConfig.itwinId, { unassignRoles : [{ email: TestConfig.temporaryUserEmail, roleIds: [TestConfig.permanentRoleId1]} ]});
+
+    // Assert
+    chai.expect(iTwinJobResponse.status).to.be.eq(201);
+    chai.expect(iTwinJobResponse.data).to.not.be.empty;
+
+    chai.expect(iTwinJobResponse.data!.itwinId).to.be.eq(TestConfig.itwinId);
+  });
+});


### PR DESCRIPTION
Releasing 3.2.0

This release contains the changes that were approved in this PR #30 (and then reverted #33).

This release adds the iTwin Jobs Client. For more information see the iTwin Jobs API documentation here: https://developer.bentley.com/apis/access-control-v2/operations/create-itwin-job/